### PR TITLE
fix: Bump APP_VERSION to 4.1.0 to force Streamlit cache refresh

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -40,7 +40,7 @@ from inflation_adjuster import (
 # VERSION & CACHE
 # =============================================================================
 
-APP_VERSION = "4.0.0"
+APP_VERSION = "4.1.0"
 
 if "app_version" not in st.session_state or st.session_state.app_version != APP_VERSION:
     st.cache_resource.clear()


### PR DESCRIPTION
Clears cached data after FLA relationship genericization changes.

https://claude.ai/code/session_01T1sKfwgiLZw5SJZ5mx1CZr